### PR TITLE
Add HYPE metric to open question 5

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -474,6 +474,11 @@
     <d-cite key="GANFIGHT,DRS"></d-cite> have shown that trained GAN discriminators can contain useful information
     with which  evaluation can be performed.
   </li>
+  <li><b>HYPE</b> -
+    <d-cite key="HYPE"></d-cite> propose Human eYe Perceptual Evaluation (HYPE), which tests generative models for 
+    how realistic their images look to the human eye. HYPE-Time measures the average time a human takes to
+    recognize that a generated image is fake; HYPE-Infinity measures the human error rate for identifying real
+    and generated images.
   </ul>
 
   <p>

--- a/static/bibliography.bib
+++ b/static/bibliography.bib
@@ -1265,3 +1265,10 @@ archivePrefix = "arXiv",
   biburl    = {https://dblp.org/rec/bib/journals/corr/abs-1809-04542},
   bibsource = {dblp computer science bibliography, https://dblp.org}
 }
+
+@article{HYPE,
+  title={HYPE: Human eYe Perceptual Evaluation of Generative Models},
+  author={Zhou, Sharon and Gordon, Mitchell and Krishna, Ranjay and Narcomey, Austin and Morina, Durim and Bernstein, Michael S},
+  journal={arXiv preprint arXiv:1904.01121},
+  year={2019}
+}


### PR DESCRIPTION
As discussed in #1, this PR adds the [Human eYe Perceptual Evaluation (HYPE) metric](https://hype.stanford.edu/), published at ICLR 2019, to the list of suggestions for open question 5.